### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# 2024-11-23: @j00bar - Added linting/styling
+e621de8a5a163bf6c7e43417ac3a8437f26b541c


### PR DESCRIPTION
The changeset that applied pre-commit's lint/style filters for the first time results in a giant no-op changeset that makes `git blame` harder to use.

This PR adds a `.git-blame-ignore-revs` file which should ignore that changeset from the blame history.

See: https://github.blog/changelog/2022-03-24-ignore-commits-in-the-blame-view-beta/